### PR TITLE
Fix #82: add integration tests for `db-versioning` modules

### DIFF
--- a/db-versioning/flyway-db/pom.xml
+++ b/db-versioning/flyway-db/pom.xml
@@ -15,8 +15,8 @@
   <name>DB versioning : Flyway</name>
 
   <properties>
-    <junit.vintage.version>5.10.1</junit.vintage.version>
-    <junit.platform.version>1.10.1</junit.platform.version>
+    <junit.vintage.version>5.10.2</junit.vintage.version>
+    <junit.platform.version>1.10.2</junit.platform.version>
   </properties>
 
   <dependencies>
@@ -39,47 +39,130 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <version>${h2.db.version}</version>
-      <scope>test</scope>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <version>5.6.15.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>${mysql.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-mysql</artifactId>
+      <version>${flyway-maven-plugin.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
     </dependency>
   </dependencies>
 
   <build>
     <plugins>
       <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>${docker-maven-plugin.version}</version>
+        <configuration>
+          <showLogs>true</showLogs>
+          <images>
+            <image>
+              <name>mysql:${mysql.version}</name>
+              <run>
+                <ports>
+                  <port>3306:3306</port>
+                </ports>
+                <env>
+                  <MYSQL_DATABASE>db</MYSQL_DATABASE>
+                  <MYSQL_ROOT_PASSWORD>some_password</MYSQL_ROOT_PASSWORD>
+                  <MYSQL_USER>user</MYSQL_USER>
+                  <MYSQL_PASSWORD>password</MYSQL_PASSWORD>
+                </env>
+                <wait>
+                  <log>starting as process 1</log>
+                  <time>20000</time>
+                </wait>
+              </run>
+            </image>
+          </images>
+        </configuration>
+
+        <!-- Connect start/stop to pre- and post- integration-test phase respectively
+        if you want to start your docker containers during integration tests -->
+        <executions>
+          <execution>
+            <id>start</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>stop</goal>
+              <goal>start</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>stop</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-maven-plugin</artifactId>
         <version>${flyway-maven-plugin.version}</version>
-
         <configuration>
-          <url>jdbc:h2:mem:flywaydb</url>
+          <url>${jdbc.url}</url>
           <user>${jdbc.username}</user>
           <password>${jdbc.password}</password>
+          <encoding>UTF-8</encoding>
+          <cleanDisabled>false</cleanDisabled>
           <locations>
             <location>some_folder/db/migration</location>
           </locations>
-          <cleanDisabled>false</cleanDisabled>
         </configuration>
 
         <executions>
           <execution>
-            <phase>process-test-resources</phase>
+            <id>execution</id>
+            <phase>integration-test</phase>
             <goals>
               <goal>clean</goal>
               <goal>migrate</goal>
             </goals>
           </execution>
         </executions>
+      </plugin>
 
-        <dependencies>
-          <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>${h2.db.version}</version>
-          </dependency>
-        </dependencies>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+
+      <!--This plugin used for running integration tests in integration-test build phase-->
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven-failsafe-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/db-versioning/flyway-db/src/main/java/by/andd3dfx/model/Person.java
+++ b/db-versioning/flyway-db/src/main/java/by/andd3dfx/model/Person.java
@@ -1,0 +1,22 @@
+package by.andd3dfx.model;
+
+import lombok.Data;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Data
+@Entity
+@Table(name = "PERSON")
+public class Person {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column
+    private String name;
+}

--- a/db-versioning/flyway-db/src/main/resources/hibernate.cfg.xml
+++ b/db-versioning/flyway-db/src/main/resources/hibernate.cfg.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE hibernate-configuration PUBLIC
+  "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+  "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+  <session-factory>
+    <property name="hibernate.connection.driver_class">com.mysql.cj.jdbc.Driver</property>
+    <property name="hibernate.connection.url">jdbc:mysql://127.0.0.1:3306/db?allowPublicKeyRetrieval=true&amp;useSSL=false</property>
+    <property name="hibernate.connection.username">root</property>
+    <property name="hibernate.connection.password">some_password</property>
+    <property name="hibernate.dialect">org.hibernate.dialect.MySQLDialect</property>
+    <property name="show_sql">true</property>
+    <property name="hibernate.id.new_generator_mappings">false</property>
+
+    <mapping class="by.andd3dfx.model.Person"/>
+  </session-factory>
+</hibernate-configuration>

--- a/db-versioning/flyway-db/src/test/java/by/andd3dfx/MigrationIT.java
+++ b/db-versioning/flyway-db/src/test/java/by/andd3dfx/MigrationIT.java
@@ -1,0 +1,41 @@
+package by.andd3dfx;
+
+import by.andd3dfx.model.Person;
+import lombok.SneakyThrows;
+import org.hibernate.cfg.Configuration;
+import org.junit.Test;
+
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MigrationIT {
+
+    @SneakyThrows
+    @Test
+    public void checkRecordsAmount() {
+        try (var sessionFactory = new Configuration().configure().buildSessionFactory()) {
+            try (var session = sessionFactory.openSession()) {
+                var emFactory = session.getEntityManagerFactory();
+                var em = emFactory.createEntityManager();
+
+                getFromDbAndCheck(em, Person.class, 3);
+            }
+        }
+    }
+
+    private <T> void getFromDbAndCheck(EntityManager em, Class<T> clazz, int expectedItemsCount) {
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaQuery<T> query = builder.createQuery(clazz);
+        Root<T> variableRoot = query.from(clazz);
+        query.select(variableRoot);
+        var items = em.createQuery(query).getResultList();
+
+        System.out.println("Retrieved next items: " + items);
+        assertThat("Wrong items count", items.size(), is(expectedItemsCount));
+    }
+}

--- a/db-versioning/liquibase-db/pom.xml
+++ b/db-versioning/liquibase-db/pom.xml
@@ -19,8 +19,107 @@
     <liquibase.version>4.21.1</liquibase.version>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <version>5.6.15.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>${mysql.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.liquibase</groupId>
+      <artifactId>liquibase-core</artifactId>
+      <version>${liquibase.version}</version>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>${docker-maven-plugin.version}</version>
+        <configuration>
+          <showLogs>true</showLogs>
+          <images>
+            <image>
+              <name>mysql:${mysql.version}</name>
+              <run>
+                <ports>
+                  <port>3306:3306</port>
+                </ports>
+                <env>
+                  <MYSQL_DATABASE>db</MYSQL_DATABASE>
+                  <MYSQL_ROOT_PASSWORD>some_password</MYSQL_ROOT_PASSWORD>
+                  <MYSQL_USER>user</MYSQL_USER>
+                  <MYSQL_PASSWORD>password</MYSQL_PASSWORD>
+                </env>
+                <wait>
+                  <log>starting as process 1</log>
+                  <time>20000</time>
+                </wait>
+              </run>
+            </image>
+          </images>
+        </configuration>
+
+        <!-- Connect start/stop to pre- and post- integration-test phase respectively
+        if you want to start your docker containers during integration tests -->
+        <executions>
+          <execution>
+            <id>start</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>stop</goal>
+              <goal>start</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>stop</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+
+      <!--This plugin used for running integration tests in integration-test build phase-->
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven-failsafe-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-maven-plugin</artifactId>
@@ -28,7 +127,7 @@
         <configuration>
           <changeLogFile>src/main/db-migration/changelog.xml</changeLogFile>
           <driver>${jdbc.driverClassName}</driver>
-          <url>jdbc:h2:file:${project.build.directory}/liquibasedb</url>
+          <url>${jdbc.url}</url>
           <username>${jdbc.username}</username>
           <password>${jdbc.password}</password>
           <outputFileEncoding>UTF-8</outputFileEncoding>
@@ -37,25 +136,12 @@
 
         <executions>
           <execution>
-            <phase>process-test-resources</phase>
+            <phase>pre-integration-test</phase>
             <goals>
               <goal>update</goal>
             </goals>
           </execution>
         </executions>
-
-        <dependencies>
-          <dependency>
-            <groupId>org.liquibase</groupId>
-            <artifactId>liquibase-core</artifactId>
-            <version>${liquibase.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>${h2.db.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/db-versioning/liquibase-db/src/main/java/by/andd3dfx/model/Person.java
+++ b/db-versioning/liquibase-db/src/main/java/by/andd3dfx/model/Person.java
@@ -1,0 +1,22 @@
+package by.andd3dfx.model;
+
+import lombok.Data;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Data
+@Entity
+@Table(name = "PERSON")
+public class Person {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column
+    private String name;
+}

--- a/db-versioning/liquibase-db/src/main/resources/hibernate.cfg.xml
+++ b/db-versioning/liquibase-db/src/main/resources/hibernate.cfg.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE hibernate-configuration PUBLIC
+  "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+  "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+  <session-factory>
+    <property name="hibernate.connection.driver_class">com.mysql.cj.jdbc.Driver</property>
+    <property name="hibernate.connection.url">jdbc:mysql://127.0.0.1:3306/db?allowPublicKeyRetrieval=true&amp;useSSL=false</property>
+    <property name="hibernate.connection.username">root</property>
+    <property name="hibernate.connection.password">some_password</property>
+    <property name="hibernate.dialect">org.hibernate.dialect.MySQLDialect</property>
+    <property name="show_sql">true</property>
+    <property name="hibernate.id.new_generator_mappings">false</property>
+
+    <mapping class="by.andd3dfx.model.Person"/>
+  </session-factory>
+</hibernate-configuration>

--- a/db-versioning/liquibase-db/src/test/java/by/andd3dfx/MigrationIT.java
+++ b/db-versioning/liquibase-db/src/test/java/by/andd3dfx/MigrationIT.java
@@ -1,0 +1,41 @@
+package by.andd3dfx;
+
+import by.andd3dfx.model.Person;
+import lombok.SneakyThrows;
+import org.hibernate.cfg.Configuration;
+import org.junit.Test;
+
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MigrationIT {
+
+    @SneakyThrows
+    @Test
+    public void checkRecordsAmount() {
+        try (var sessionFactory = new Configuration().configure().buildSessionFactory()) {
+            try (var session = sessionFactory.openSession()) {
+                var emFactory = session.getEntityManagerFactory();
+                var em = emFactory.createEntityManager();
+
+                getFromDbAndCheck(em, Person.class, 3);
+            }
+        }
+    }
+
+    private <T> void getFromDbAndCheck(EntityManager em, Class<T> clazz, int expectedItemsCount) {
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaQuery<T> query = builder.createQuery(clazz);
+        Root<T> variableRoot = query.from(clazz);
+        query.select(variableRoot);
+        var items = em.createQuery(query).getResultList();
+
+        System.out.println("Retrieved next items: " + items);
+        assertThat("Wrong items count", items.size(), is(expectedItemsCount));
+    }
+}

--- a/db-versioning/pom.xml
+++ b/db-versioning/pom.xml
@@ -14,10 +14,11 @@
   <name>DB versioning : Root</name>
 
   <properties>
-    <jdbc.driverClassName>org.h2.Driver</jdbc.driverClassName>
-    <jdbc.url>dbc:h2:mem:liquibase</jdbc.url>
-    <jdbc.username>liquibase</jdbc.username>
-    <jdbc.password></jdbc.password>
+    <mysql.version>8.0.28</mysql.version>
+    <jdbc.driverClassName>com.mysql.cj.jdbc.Driver</jdbc.driverClassName>
+    <jdbc.url>jdbc:mysql://127.0.0.1:3306/db?allowPublicKeyRetrieval=true&amp;useSSL=false</jdbc.url>
+    <jdbc.username>root</jdbc.username>
+    <jdbc.password>some_password</jdbc.password>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/hibernate-mappings/pom.xml
+++ b/hibernate-mappings/pom.xml
@@ -85,7 +85,7 @@
         <executions>
           <execution>
             <id>execution</id>
-            <phase>integration-test</phase>
+            <phase>pre-integration-test</phase>
             <goals>
               <goal>clean</goal>
               <goal>migrate</goal>


### PR DESCRIPTION
For modules which contain DB migration (Flyway & Liquibase) switched from H2 to MySQL database and added Integration test to check migration fact & quality.